### PR TITLE
Librarian view modal title doesn't look right after bootstrap 4 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to Blacklight-marc project will be documented in this file. Blacklight-marc is Project Blacklight's MARC-specific enhancements for Blacklight that University of Alberta Libraries has forked at version 5.10.0: http://projectblacklight.org/. https://library.ualberta.ca/.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and releases in Blacklight-marc project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Made librarian view modal title look proper [#1](https://github.com/ualbertalib/blacklight-marc/issues/1)

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,7 +1,7 @@
 
 <div class="modal-header">
-  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
   <h3 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h3>
+  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
 </div>
 <%- if @document.respond_to?(:to_marc) -%>
   <%= render "marc_view" %>


### PR DESCRIPTION
- Moved the h3 container to be before the button container in librarian_view.html.erb
- Added a changelog
#1 
Screenshots below:
Before:
![Screenshot from 2019-05-24 15-44-06](https://user-images.githubusercontent.com/14242562/58359181-63910a80-7e3f-11e9-86a2-127247fad8f1.png)
After:
![Screenshot from 2019-05-24 16-16-42](https://user-images.githubusercontent.com/14242562/58359186-6986eb80-7e3f-11e9-80e1-421d1c74a730.png)

